### PR TITLE
[FIX-BIPARTITE-CHECK] check disconnected components too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.41.0  # MSRV
+          - rust: 1.46.0  # MSRV
           - rust: stable
             features: unstable quickcheck
             test_all: --all

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-msrv = "1.41.0"
+msrv = "1.46.0" # see https://github.com/rust-lang/rust/issues/58957

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -765,53 +765,51 @@ pub struct NegativeCycle(pub ());
 /// Always treats the input graph as if undirected.
 pub fn is_bipartite_undirected<G, N, VM>(g: G) -> bool
 where
-        G: GraphRef
-                + Visitable<NodeId = N, Map = VM>
-                + IntoNeighbors<NodeId = N>
-                + IntoNodeIdentifiers<NodeId = N>,
-        N: Copy + PartialEq + std::fmt::Debug,
-        VM: VisitMap<N>,
+    G: GraphRef
+        + Visitable<NodeId = N, Map = VM>
+        + IntoNeighbors<NodeId = N>
+        + IntoNodeIdentifiers<NodeId = N>,
+    N: Copy + PartialEq + std::fmt::Debug,
+    VM: VisitMap<N>,
 {
-        let node_ids: Vec<N> = g.node_identifiers().map(|id| id).collect();
+    let node_ids: Vec<N> = g.node_identifiers().map(|id| id).collect();
 
-        let mut red = g.visit_map();
-        let mut blue = g.visit_map();
+    let mut red = g.visit_map();
+    let mut blue = g.visit_map();
 
-        for node in node_ids {
-                for neighbor in g.neighbors(node) {
-                        let is_blue = blue.is_visited(&node);
-                        let is_red = red.is_visited(&node);
-                        let is_neighbor_blue = blue.is_visited(&neighbor);
-                        let is_neighbor_red = red.is_visited(&neighbor);
+    for node in node_ids {
+        for neighbor in g.neighbors(node) {
+            let is_blue = blue.is_visited(&node);
+            let is_red = red.is_visited(&node);
+            let is_neighbor_blue = blue.is_visited(&neighbor);
+            let is_neighbor_red = red.is_visited(&neighbor);
 
-                        match (is_blue, is_red, is_neighbor_blue, is_neighbor_red) {
-                                (false, false, false, false) => {
-                                        blue.visit(node);
-                                        red.visit(neighbor);
-                                }
-                                (false, false, false, true) => {
-                                        blue.visit(node);
-                                }
-                                (false, false, true, false) => {
-                                        red.visit(node);
-                                }
-                                (true, false, false, false) => {
-                                        red.visit(neighbor);
-                                }
-                                (true, false, false, true) => {
-                                        continue;
-                                }
-                                (false, true, true, false) => {
-                                        continue;
-                                }
-                                (_, _, _, _) => {
-                                        return false
-                                }
-                        }
+            match (is_blue, is_red, is_neighbor_blue, is_neighbor_red) {
+                (false, false, false, false) => {
+                    blue.visit(node);
+                    red.visit(neighbor);
                 }
+                (false, false, false, true) => {
+                    blue.visit(node);
+                }
+                (false, false, true, false) => {
+                    red.visit(node);
+                }
+                (true, false, false, false) => {
+                    red.visit(neighbor);
+                }
+                (true, false, false, true) => {
+                    continue;
+                }
+                (false, true, true, false) => {
+                    continue;
+                }
+                (_, _, _, _) => return false,
+            }
         }
+    }
 
-        true
+    true
 }
 
 use std::fmt::Debug;

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -294,21 +294,21 @@ fn bipartite() {
         gr.add_edge(a, d, 7.);
         gr.add_edge(b, d, 6.);
 
-        assert!(is_bipartite_undirected(&gr, a));
+        assert!(is_bipartite_undirected(&gr));
 
         let e_index = gr.add_edge(a, b, 6.);
 
-        assert!(!is_bipartite_undirected(&gr, a));
+        assert!(!is_bipartite_undirected(&gr));
 
         gr.remove_edge(e_index);
 
-        assert!(is_bipartite_undirected(&gr, a));
+        assert!(is_bipartite_undirected(&gr));
 
         gr.add_edge(b, e, 7.);
         gr.add_edge(b, f, 6.);
         gr.add_edge(c, e, 6.);
 
-        assert!(is_bipartite_undirected(&gr, a));
+        assert!(is_bipartite_undirected(&gr));
     }
     {
         let mut gr = Graph::new_undirected();
@@ -342,11 +342,95 @@ fn bipartite() {
         gr.add_edge(e, g, 6.);
         gr.add_edge(e, h, 6.);
 
-        assert!(is_bipartite_undirected(&gr, a));
+        assert!(is_bipartite_undirected(&gr));
 
         gr.add_edge(a, b, 6.);
 
-        assert!(!is_bipartite_undirected(&gr, a));
+        assert!(!is_bipartite_undirected(&gr));
+    }
+    {
+        let mut gr = Graph::new_undirected();
+        let a = gr.add_node("A");
+        let b = gr.add_node("B");
+        let c = gr.add_node("C");
+        let d = gr.add_node("D");
+
+        let e = gr.add_node("E");
+        let f = gr.add_node("F");
+        let g = gr.add_node("G");
+        let h = gr.add_node("H");
+
+        gr.add_edge(a, f, 6.);
+
+        gr.add_edge(b, g, 6.);
+        gr.add_edge(b, h, 6.);
+
+        gr.add_edge(c, f, 6.);
+
+        gr.add_edge(d, e, 6.);
+        gr.add_edge(d, f, 6.);
+
+        assert!(is_bipartite_undirected(&gr));
+
+        // b -> g -> h -> b is a disconnected cycle
+        gr.add_edge(g, h, 6.);
+
+        assert!(!is_bipartite_undirected(&gr));
+    }
+    {
+        let mut gr = Graph::new_undirected();
+        let a = gr.add_node("A");
+
+        let b = gr.add_node("B");
+        let c = gr.add_node("C");
+        let d = gr.add_node("D");
+        let e = gr.add_node("E");
+        let f = gr.add_node("F");
+
+        gr.add_edge(a, b, 6.);
+        gr.add_edge(a, c, 6.);
+        gr.add_edge(a, d, 6.);
+        gr.add_edge(a, e, 6.);
+        gr.add_edge(a, f, 6.);
+
+        assert!(is_bipartite_undirected(&gr));
+
+        gr.add_edge(e, f, 6.);
+
+        assert!(!is_bipartite_undirected(&gr));
+    }
+    {
+        let mut gr = Graph::new_undirected();
+        let a = gr.add_node("A");
+        let b = gr.add_node("B");
+        let c = gr.add_node("C");
+        let d = gr.add_node("D");
+        let e = gr.add_node("E");
+
+        let f = gr.add_node("F");
+        let g = gr.add_node("B");
+        let h = gr.add_node("C");
+        let i = gr.add_node("D");
+        let j = gr.add_node("E");
+
+        gr.add_edge(a, g, 6.);
+        gr.add_edge(a, h, 6.);
+        gr.add_edge(b, f, 6.);
+        gr.add_edge(b, g, 6.);
+        gr.add_edge(b, i, 6.);
+        gr.add_edge(b, j, 6.);
+        gr.add_edge(c, g, 6.);
+        gr.add_edge(c, h, 6.);
+        gr.add_edge(d, g, 6.);
+        gr.add_edge(d, h, 6.);
+        gr.add_edge(e, i, 6.);
+        gr.add_edge(e, j, 6.);
+
+        assert!(is_bipartite_undirected(&gr));
+
+        gr.add_edge(f, j, 6.);
+
+        assert!(!is_bipartite_undirected(&gr));
     }
 }
 


### PR DESCRIPTION
1. If there is a disconnected component in the graph, the current method does not check that. The new method iterates through all the nodes(which might not be needed). Not sure if there are any other cases which will fail.
2. upgrade the rust version to `1.46.0`. This will fix the issue https://github.com/rust-lang/rust/issues/58957